### PR TITLE
remove references to http endpoints, deadspace in resources.py

### DIFF
--- a/app/resources.py
+++ b/app/resources.py
@@ -1,4 +1,3 @@
-
 import re
 import glob
 import shutil
@@ -14,8 +13,6 @@ from pymongo import MongoClient
 from tasks.tasks import do_task, get_end_message
 import random
 
-#celery_client = Celery('tasks')
-#celery_client.config_from_object('celeryconfig')
 
 incoming_queue = os.environ.get('FIRST_QUEUE_NAME', 'first_queue')
 transform_jstorforum_queue = os.environ.get('SECOND_QUEUE_NAME', 'transform_jstorforum')
@@ -29,9 +26,6 @@ def define_resources(app):
     dashboard = api.namespace('/', description="This project contains the integration tests for the JSTOR project")
 
     # Env vars
-    harvester_endpoint = os.environ.get('HARVESTER_ENDPOINT')
-    publisher_endpoint = os.environ.get('PUBLISHER_ENDPOINT')
-    transformer_endpoint = os.environ.get('TRANSFORMER_ENDPOINT')
     mongo_url = os.environ.get('MONGO_URL')
     mongo_dbname = os.environ.get('MONGO_DBNAME')
     mongo_collection_name = os.environ.get('MONGO_COLLECTION')

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -18,7 +18,7 @@ services:
       QUEUE_NAME: first_queue_itest
     ports:
       # Integration tests
-      - '24005:8081'
+      - '25003:8081'
     networks:
       - jstorforum-net
 

--- a/env-example.txt
+++ b/env-example.txt
@@ -6,10 +6,6 @@ MONGO_URL=mongodb://USERNAME:PASSWORD@mongo-dev-1.lts.harvard.edu:27072,mongo-de
 MONGO_DBNAME=jstorforum-dev
 MONGO_COLLECTION=integration_test
 
-HARVESTER_ENDPOINT=http://locahost:24006/jstor_harvester
-TRANSFORMER_ENDPOINT=http://locahost:24007/jstor_transformer
-PUBLISHER_ENDPOINT=http://locahost:24008/jstor_publisher
-
 FIRST_QUEUE_NAME=first_queue_itest
 SECOND_QUEUE_NAME=transform_jstorforum_itest
 THIRD_QUEUE_NAME=publish_jstorforum_itest

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -9,7 +9,7 @@ incoming_queue = os.environ.get('FIRST_QUEUE_NAME', 'first_queue_itest')
 transform_jstorforum_queue = os.environ.get('SECOND_QUEUE_NAME', 'transform_jstorforum_itest')
 publish_jstorforum_queue = os.environ.get('THIRD_QUEUE_NAME', 'publish_jstorforum_itest')
 completed_jstorforum_queue = os.environ.get('LAST_QUEUE_NAME', 'completed_jstorforum_itest')
-harvester_endpoint = os.environ.get('HARVESTER_ENDPOINT')
+
 retry_strategy = Retry(
     total=3,
     status_forcelist=[429, 500, 502, 503, 504],
@@ -22,9 +22,7 @@ http_client.mount("http://", adapter)
 
 @celery.task(ignore_result=False, acks_late=True)
 def do_task(message):
-    url = harvester_endpoint + "/do_task"
     response = celeryapp.execute.send_task("tasks.tasks.do_task", args=[message], kwargs={}, queue=incoming_queue)
-    #response = http_client.post(url, json = message, verify=False)
     return response
 
 @celery.task(queue=completed_jstorforum_queue)


### PR DESCRIPTION
**remove references to http endpoints, dead space in resources.py.**
* * *

**JIRA Ticket**: n/a

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
this removes unused http endpoints and empty whitespace in resources.y

# How should this be tested?

1.  `docker-compose -f docker-compose-local.yml up -d --build --force-recreate` to start container
2. ` curl -k "https://10.1.79.8:24005/integration"   `  - you should see `{"num_failed": 0, "tests_failed": [], "info": {}}` as successful response message
3. `docker-compose -f docker-compose-local.yml down ` to stop container

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? no
- integration tests? this is the integration test

# Interested parties
Tag (@ mention) interested parties
